### PR TITLE
feat(relaunch-terminal): add module to relaunch active VS Code terminal via Alt+F

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -61,6 +61,7 @@ local lockScreen = require("modules.lock_screen")
 local autoFullscreen = require("modules.auto_fullscreen")
 local cmdDAndCmd4 = require("modules.cmd_d_and_4")
 local resetVSCode = require("modules.reset_vscode")
+local relaunchTerminal = require("modules.relaunch_terminal")
 
 autoBrightness.start()
 keepalive.start({
@@ -89,6 +90,7 @@ lockScreen.bindHotkey()
 appNavigation.bindHotkey()
 cmdDAndCmd4.bindHotkey()
 resetVSCode.bindHotkey()
+relaunchTerminal.bindHotkey()
 
 print("✅ Hammerspoon Productivity Toolkit initialized.")
 hs.alert.show("🎉 All automations active")

--- a/modules/relaunch_terminal.lua
+++ b/modules/relaunch_terminal.lua
@@ -1,0 +1,30 @@
+-- luacheck: globals hs
+-- luacheck: max line length 120
+local M = {}
+
+local HOTKEY_MODS = {"alt"}
+local HOTKEY_KEY  = "f"
+
+local function relaunchTerminal()
+    local app = hs.application.find("Code")
+    if not app then
+        hs.alert.show("VS Code not running")
+        return
+    end
+    app:activate()
+    hs.timer.doAfter(0.2, function()
+        hs.eventtap.keyStroke({"cmd", "shift"}, "p")
+        hs.timer.doAfter(0.3, function()
+            hs.eventtap.keyStrokes("relaunch active terminal")
+            hs.timer.doAfter(0.3, function()
+                hs.eventtap.keyStroke({}, "return")
+            end)
+        end)
+    end)
+end
+
+function M.bindHotkey()
+    hs.hotkey.bind(HOTKEY_MODS, HOTKEY_KEY, relaunchTerminal)
+end
+
+return M

--- a/modules/relaunch_terminal.lua
+++ b/modules/relaunch_terminal.lua
@@ -6,7 +6,7 @@ local HOTKEY_MODS = {"alt"}
 local HOTKEY_KEY  = "f"
 
 local function relaunchTerminal()
-    local app = hs.application.find("Code")
+    local app = hs.application.find("Code") or hs.application.find("Visual Studio Code")
     if not app then
         hs.alert.show("VS Code not running")
         return

--- a/tests/test_all_modules.lua
+++ b/tests/test_all_modules.lua
@@ -16,7 +16,8 @@ local modules = {
     "teams_focus_restore",
     "vscode_window_manager",
     "window_cycle",
-    "reset_vscode"
+    "reset_vscode",
+    "relaunch_terminal"
 }
 for _, name in ipairs(modules) do
     require("modules." .. name)

--- a/tests/test_relaunch_terminal.lua
+++ b/tests/test_relaunch_terminal.lua
@@ -1,0 +1,144 @@
+-- luacheck: globals hs busted describe it assert before_each
+-- luacheck: ignore busted
+
+-- Unit tests for modules/relaunch_terminal.lua
+-- Verifies the public interface and the VS Code command-palette flow without
+-- triggering real keyboard events or application focus changes.
+
+_G.hs = _G.hs or {}
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- Minimal hs stubs required by the module
+-- ──────────────────────────────────────────────────────────────────────────────
+
+hs.hotkey = hs.hotkey or {
+    bind = function() end
+}
+
+hs.alert = hs.alert or {
+    show = function() end
+}
+
+hs.timer = hs.timer or {
+    doAfter = function(_, fn) if fn then fn() end end
+}
+
+hs.eventtap = hs.eventtap or {
+    keyStroke  = function() end,
+    keyStrokes = function() end,
+}
+
+hs.application = hs.application or {
+    find = function() return nil end
+}
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- Tests
+-- ──────────────────────────────────────────────────────────────────────────────
+
+describe("relaunch_terminal", function()
+    local capturedFn
+    local alertShown
+    local activated
+    local keyStrokeCalls
+    local keyStrokesCalls
+
+    before_each(function()
+        capturedFn      = nil
+        alertShown      = nil
+        activated       = false
+        keyStrokeCalls  = {}
+        keyStrokesCalls = {}
+
+        _G.hs.hotkey.bind = function(_, _, fn) capturedFn = fn end
+        _G.hs.alert.show  = function(msg) alertShown = msg end
+        _G.hs.timer.doAfter = function(_, fn) if fn then fn() end end
+        _G.hs.eventtap.keyStroke  = function(mods, key)
+            table.insert(keyStrokeCalls, {mods = mods, key = key})
+        end
+        _G.hs.eventtap.keyStrokes = function(text)
+            table.insert(keyStrokesCalls, text)
+        end
+        _G.hs.application.find = function() return nil end
+
+        package.loaded["modules.relaunch_terminal"] = nil
+    end)
+
+    it("returns a module table", function()
+        local m = require("modules.relaunch_terminal")
+        assert.is_table(m)
+    end)
+
+    it("exposes bindHotkey as a function", function()
+        local m = require("modules.relaunch_terminal")
+        assert.is_function(m.bindHotkey)
+    end)
+
+    it("shows alert when VS Code is not running", function()
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        assert.is_function(capturedFn)
+        capturedFn()
+        assert.is_not_nil(alertShown)
+        assert.truthy(alertShown:find("VS Code"))
+    end)
+
+    it("does not send keystrokes when VS Code is not running", function()
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        capturedFn()
+        assert.equals(0, #keyStrokeCalls)
+        assert.equals(0, #keyStrokesCalls)
+    end)
+
+    it("activates VS Code when found", function()
+        _G.hs.application.find = function() return {activate = function() activated = true end} end
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        capturedFn()
+        assert.is_true(activated)
+    end)
+
+    it("opens the command palette with Cmd+Shift+P when VS Code is found", function()
+        _G.hs.application.find = function() return {activate = function() end} end
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        capturedFn()
+        local found = false
+        for _, call in ipairs(keyStrokeCalls) do
+            if call.key == "p" then
+                local hasCmd, hasShift = false, false
+                for _, mod in ipairs(call.mods) do
+                    if mod == "cmd"   then hasCmd   = true end
+                    if mod == "shift" then hasShift = true end
+                end
+                if hasCmd and hasShift then found = true end
+            end
+        end
+        assert.is_true(found)
+    end)
+
+    it("types 'relaunch active terminal' into the command palette", function()
+        _G.hs.application.find = function() return {activate = function() end} end
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        capturedFn()
+        local found = false
+        for _, text in ipairs(keyStrokesCalls) do
+            if text:find("relaunch active terminal") then found = true end
+        end
+        assert.is_true(found)
+    end)
+
+    it("sends Return to confirm the command", function()
+        _G.hs.application.find = function() return {activate = function() end} end
+        local m = require("modules.relaunch_terminal")
+        m.bindHotkey()
+        capturedFn()
+        local found = false
+        for _, call in ipairs(keyStrokeCalls) do
+            if call.key == "return" then found = true end
+        end
+        assert.is_true(found)
+    end)
+end)


### PR DESCRIPTION
## Summary

- Adds `modules/relaunch_terminal.lua`: binds **Option+F** to execute the VS Code command **"Terminal: Relaunch Active Terminal"** via the command palette (`Cmd+Shift+P` → type → `Return`)
- Registers the module in `init.lua` alongside the other `bindHotkey` modules
- Adds `tests/test_relaunch_terminal.lua` with 8 unit tests covering all branches (VS Code not running, activation, command-palette keystrokes, typed text, Return confirmation)
- Updates `tests/test_all_modules.lua` to include `relaunch_terminal` in the coverage sweep

## Test plan

- [ ] `busted --coverage tests/ --pattern='test_.*.lua'` — 44 successes, 0 failures
- [ ] `luacheck modules/` — 0 warnings, 0 errors in 16 files
- [ ] Pre-commit hooks pass on all changed files
- [ ] Reload Hammerspoon config and press **Option+F** while VS Code is focused — terminal should relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)